### PR TITLE
fix: DECCKM "application mode" esc sequences

### DIFF
--- a/src/ui.zig
+++ b/src/ui.zig
@@ -156,7 +156,8 @@ fn readKey(terminal: *Terminal) Key {
         seq[0] = reader.readByte() catch return .esc;
         seq[1] = reader.readByte() catch return .esc;
 
-        if (seq[0] == '[') {
+        // DECCKM mode sends \x1bO* instead of \x1b[*
+        if (seq[0] == '[' or seq[0] == 'O') { 
             return switch (seq[1]) {
                 'A' => .up,
                 'B' => .down,


### PR DESCRIPTION
Adds support for ESC O * prefix in addition to ANSI ESC [ * prefix.

See https://vt100.net/docs/vt102-ug/appendixc.html