### PR TITLE
Update control keys so that ctrl-p goes up

### DIFF
--- a/src/tui/ui.zig
+++ b/src/tui/ui.zig
@@ -253,9 +253,9 @@ pub const State = struct {
                     state.query.moveCursor(1, .right);
                 } else if (key.matches('b', .{ .ctrl = true }) or key.matches(Key.left, .{})) {
                     state.query.moveCursor(1, .left);
-                } else if (key.matches(Key.down, .{}) or key.matches('p', .{ .ctrl = true }) or key.matches('n', .{ .ctrl = true })) {
+                } else if (key.matches(Key.down, .{}) or key.matches('n', .{ .ctrl = true })) {
                     lineDown(state, visible_rows, num_filtered - visible_rows);
-                } else if (key.matches(Key.up, .{})) {
+                } else if (key.matches(Key.up, .{}) or key.matches('p', .{ .ctrl = true })) {
                     lineUp(state);
                 } else if (key.matches('k', .{ .ctrl = true })) {
                     if (state.config.vi_mode) lineUp(state) else state.query.deleteTo(state.query.len());


### PR DESCRIPTION
Expected behavior of ctrl-p is to move up a line of output but instead it was moving down.

I frequently use emacs shortcuts for moving up and down lines and I noticed this. Made a single change so that it works as expected now.