### PR TITLE
Fix for Overflow Error when using <C-w> after using <C-b>

### DIFF
--- a/src/tui/ui.zig
+++ b/src/tui/ui.zig
@@ -430,6 +430,8 @@ pub const State = struct {
 
 /// Deletes a word to the left of the cursor. Words are separated by space or slash characters
 fn deleteWord(query: *EditBuffer) void {
+    if (query.cursor == 0) return;
+
     var slice = query.slice()[0..query.cursor];
     var end = slice.len - 1;
 


### PR DESCRIPTION
Fix for Overflow Error when using **Control-w** after using **Control-b**

[zf_cw.webm](https://github.com/user-attachments/assets/e8fe7e16-8122-4eb0-9870-e0f0a7fcedc8)
