### PR TITLE
ctrl-j mapping for line-down was missing. Reference: https://github.c…

### DIFF
--- a/src/tui/ui.zig
+++ b/src/tui/ui.zig
@@ -253,7 +253,7 @@ pub const State = struct {
                     state.query.moveCursor(1, .right);
                 } else if (key.matches('b', .{ .ctrl = true }) or key.matches(Key.left, .{})) {
                     state.query.moveCursor(1, .left);
-                } else if (key.matches(Key.down, .{}) or key.matches('n', .{ .ctrl = true })) {
+                } else if (key.matches(Key.down, .{}) or key.matches('n', .{ .ctrl = true }) or key.matches('j', .{ .ctrl = true })) {
                     lineDown(state, visible_rows, num_filtered - visible_rows);
                 } else if (key.matches(Key.up, .{}) or key.matches('p', .{ .ctrl = true })) {
                     lineUp(state);


### PR DESCRIPTION
Reference : https://github.com/rockorager/libvaxis/pull/149

Making sure ctrl-j is actually mapped for line-down, the docs mention ctrl-j should go line-down

https://github.com/natecraddock/zf/blob/main/doc/zf.md