### PR TITLE
update libvaxis

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .version = "0.10.3",
     .dependencies = .{
         .vaxis = .{
-            .url = "git+https://github.com/rockorager/libvaxis/?ref=main#6a37605dde55898dcca4769dd3eb1e333959c209",
-            .hash = "vaxis-0.1.0-BWNV_K3yCACrTy3A5cbZElLyICx5a2O2EzPxmgVRcbKJ",
+            .url = "git+https://github.com/rockorager/libvaxis/?ref=main#4182b7fa42f27cf14a71dbdb54cfd82c5c6e3447",
+            .hash = "vaxis-0.1.0-BWNV_MHyCAA0rNbPTr50Z44PyEdNP9zQSnHcXBXoo3Ti",
             .lazy = true,
         },
     },


### PR DESCRIPTION
libvaxis had a transitive dependency on a zigimg commit that hadn't been merged into the repository, which is [causing problems downstream for Ghostty.](https://github.com/ghostty-org/ghostty/issues/6734)

libvaxis has now [merged a fix for that](https://github.com/rockorager/libvaxis/pull/179), but to completely fix the issue, all users of the affected libvaxis version need to be updated.