### PR TITLE
update libvaxis for zigimg transitive dep (again)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .version = "0.10.3",
     .dependencies = .{
         .vaxis = .{
-            .url = "git+https://github.com/rockorager/libvaxis/?ref=main#4182b7fa42f27cf14a71dbdb54cfd82c5c6e3447",
-            .hash = "vaxis-0.1.0-BWNV_MHyCAA0rNbPTr50Z44PyEdNP9zQSnHcXBXoo3Ti",
+            .url = "git+https://github.com/rockorager/libvaxis#1f41c121e8fc153d9ce8c6eb64b2bbab68ad7d23",
+            .hash = "vaxis-0.1.0-BWNV_FUICQAFZnTCL11TUvnUr1Y0_ZdqtXHhd51d76Rn",
             .lazy = true,
         },
     },


### PR DESCRIPTION
The zigimg commit that libvaxis was depending on got orphaned again so all downstream users need to switch to a new commit of libvaxis that uses a non-orphaned zigimg commit.