### PR TITLE
docs: mention nix flakes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ brew install zf
 nix-env --install zf
 ```
 
+### Nix Flakes
+
+```
+nix profile install nixpkgs#zf
+```
+
 ### Binaries
 
 Each [release](https://github.com/natecraddock/zf/releases/latest) has binaries attached for macOS and Linux.


### PR DESCRIPTION
Nix Flakes is a newer approach to installing packages with Nix, and is currently in beta. Flakes have been in beta for several years already and have gained significant adoption despite its status.

Another reason I believe flakes are worthy of mention is because `nix profile install` has significantly higher performance compared to `nix-env`.